### PR TITLE
#6 Fix rendering an image from view

### DIFF
--- a/Sources/FlipBook/View.swift
+++ b/Sources/FlipBook/View.swift
@@ -61,12 +61,9 @@ extension View {
     }
     
     func fb_makeViewSnapshot() -> Image? {
-        UIGraphicsBeginImageContextWithOptions(frame.size, true, 0)
-        guard let context = UIGraphicsGetCurrentContext() else { return nil }
-        layer.presentation()?.render(in: context)
-        let rasterizedView = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return rasterizedView
+        UIGraphicsImageRenderer(size: bounds.size).image { rendererContext in
+            drawHierarchy(in: bounds, afterScreenUpdates: false)
+        }
     }
 }
 #endif


### PR DESCRIPTION
This PR addresses the issue #6. Personally, I faced a crash when I was rendering a [`MKMapView`](https://developer.apple.com/documentation/mapkit/mkmapview).

For making a snapshot:
- Use [`drawHierarchy`](https://developer.apple.com/documentation/uikit/uiview/1622589-drawhierarchy) function instead of layer's [`render`](https://developer.apple.com/documentation/quartzcore/calayer/1410909-render).
- Use a modern [`UIGraphicsImageRenderer`](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer) instead of pair `UIGraphicsBeginImageContextWithOptions` - `UIGraphicsEndImageContext`.

The first thing, actually, fixes the bug. The second one is just good, plus the outcome is a non-optional image.